### PR TITLE
📈ヒートマップを表示できるようにしてみた

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,17 @@
 
     <script src="./script.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/mvp.css" />
+    <style type="text/css">
+      #stastics:not(.heatmap) tbody td {
+        background-color: inherit !important;
+      }
+      #stastics.heatmap thead td {
+        background-color: var(--color-text);
+      }
+      #stastics.heatmap tbody tr {
+        background-color: var(--color-bg);
+      }
+    </style>
   </head>
 
   <body>
@@ -22,14 +33,23 @@
       <textarea name="csv" cols="100" rows="10" id="csv"></textarea>
     </p>
     <p>
-      <a
-        href="https://github.com/norimiso/beat-motivator"
-      >Github</a
-      >
+      <a href="https://github.com/norimiso/beat-motivator">Github</a>
       はこちら。
     </p>
     <p><input type="button" value="submit" id="sub" /></p>
-    <p><input type="checkbox" name="check_12" id="check_12" value="true"/><label for="check_12">Shows only 12</label></p>
+    <p>
+      <input type="checkbox" name="check_12" id="check_12" value="true" /><label
+        for="check_12"
+        >Shows only 12</label
+      >
+      <input
+        type="checkbox"
+        name="enable_heatmap"
+        id="enable_heatmap"
+        value="true"
+        onClick="toggleHeatmap(this.checked);"
+      /><label for="enable_heatmap">Enable heatmap</label>
+    </p>
     <p id="tweet_button"></p>
     <p id="stastics"></p>
     <p id="list"></p>

--- a/public/index.html
+++ b/public/index.html
@@ -9,13 +9,13 @@
     <script src="./script.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/mvp.css" />
     <style type="text/css">
-      #stastics:not(.heatmap) tbody td {
+      #statistics:not(.heatmap) tbody td {
         background-color: inherit !important;
       }
-      #stastics.heatmap thead td {
+      #statistics.heatmap thead td {
         background-color: var(--color-text);
       }
-      #stastics.heatmap tbody tr {
+      #statistics.heatmap tbody tr {
         background-color: var(--color-bg);
       }
     </style>
@@ -51,7 +51,7 @@
       /><label for="enable_heatmap">Enable heatmap</label>
     </p>
     <p id="tweet_button"></p>
-    <p id="stastics"></p>
+    <p id="statistics"></p>
     <p id="list"></p>
   </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -38,10 +38,10 @@ function setTextareaData() {
   raw_data = document.getElementById("csv").value;
   let data = processCsv(raw_data);
   document.getElementById("list").innerHTML = data["list"];
-  document.getElementById("stastics").innerHTML = data["stastics"];
+  document.getElementById("statistics").innerHTML = data["statistics"];
   let tweet_url =
     '<a href="https://twitter.com/intent/tweet?hashtags=beat_motivator&ref_src=twsrc%5Etfw&text=' +
-    encodeURI(data["stastics_summary"]) +
+    encodeURI(data["statistics_summary"]) +
     '&tw_p=tweetbutton&url=https%3A%2F%2Fgoofy-wiles-fc39fe.netlify.app%2F" target="_blank" rel="noopener noreferrer"> Tweet your IIDX stats!! </a>';
   document.getElementById("tweet_button").innerHTML = tweet_url;
 }
@@ -253,8 +253,8 @@ function processCsv(csv) {
 
   console.dir(stats);
 
-  let stastics = ["<table>"];
-  let stastics_header = `
+  let statistics = ["<table>"];
+  let statistics_header = `
     <thead>
     <tr>
     <td> ☆ </td>
@@ -274,13 +274,13 @@ function processCsv(csv) {
     </tr>
     </thead>
     `;
-  stastics.push(stastics_header);
+  statistics.push(statistics_header);
   for (let i = 12; i >= 1; i--) {
     const row = stats[i];
-    stastics.push("<tr>");
-    stastics.push("<td>" + "☆" + i + "</td>");
-    stastics.push("<td>" + row["played"] + "/" + row["total"] + "</td>");
-    stastics.push("<td>" + (row["average_rate"] * 100).toFixed(3) + "%</td>");
+    statistics.push("<tr>");
+    statistics.push("<td>" + "☆" + i + "</td>");
+    statistics.push("<td>" + row["played"] + "/" + row["total"] + "</td>");
+    statistics.push("<td>" + (row["average_rate"] * 100).toFixed(3) + "%</td>");
     [
       "1keta",
       "2keta",
@@ -290,12 +290,12 @@ function processCsv(csv) {
       "AA",
       "A",
     ].forEach((name) => {
-      stastics.push(createStasticsCell(row, name));
+      statistics.push(createStatisticsCell(row, name));
     });
   }
-  stastics.push("</table>");
+  statistics.push("</table>");
 
-  let stastics_summary = [];
+  let statistics_summary = [];
   let num_1keta = 0;
   let num_99p = 0;
   let num_98p = 0;
@@ -316,7 +316,7 @@ function processCsv(csv) {
       temp += "97%: " + stats[i]["97%"] + " / ";
       temp += "max-: " + stats[i]["MAX-"] + " / ";
       temp += "AAA: " + stats[i]["AAA"] + "\n";
-      stastics_summary.push(temp);
+      statistics_summary.push(temp);
     } else if (i === 11) {
       temp +=
         "☆11 avg: " +
@@ -332,17 +332,17 @@ function processCsv(csv) {
       temp += "97%: " + stats[i]["97%"] + " / ";
       temp += "max-: " + stats[i]["MAX-"] + " / ";
       temp += "AAA: " + stats[i]["AAA"] + "\n";
-      stastics_summary.push(temp);
+      statistics_summary.push(temp);
     }
     num_1keta += stats[i]["1keta"];
     num_99p += stats[i]["99%"];
     num_98p += stats[i]["98%"];
   }
-  stastics_summary.push("Total | max-*: " + num_1keta + " / ");
-  stastics_summary.push("99%: " + num_99p + " / ");
-  stastics_summary.push("98%: " + num_98p + "\n\n");
+  statistics_summary.push("Total | max-*: " + num_1keta + " / ");
+  statistics_summary.push("99%: " + num_99p + " / ");
+  statistics_summary.push("98%: " + num_98p + "\n\n");
 
-  console.log(stastics_summary.join(""));
+  console.log(statistics_summary.join(""));
 
   let list = ["<table>"];
   let list_header = `
@@ -380,14 +380,14 @@ function processCsv(csv) {
 
   return {
     list: list.join(""),
-    stastics: stastics.join(""),
-    stastics_summary: stastics_summary.join(""),
+    statistics: statistics.join(""),
+    statistics_summary: statistics_summary.join(""),
   };
 }
 
 const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
-function createStasticsCell(row, name) {
+function createStatisticsCell(row, name) {
   const value = row[name];
   const alpha = value / row["total"];
   const style =
@@ -403,5 +403,5 @@ window.onload = function () {
 };
 
 function toggleHeatmap(checked) {
-  document.getElementById("stastics").classList.toggle("heatmap", checked);
+  document.getElementById("statistics").classList.toggle("heatmap", checked);
 }

--- a/public/script.js
+++ b/public/script.js
@@ -148,7 +148,7 @@ function processCsv(csv) {
           temp["max-"] =
             master_data_song[key]["notes"] * 2 - song[difficulty + "_score"];
           // rate validation
-          if (temp["rate"] < 0){
+          if (temp["rate"] < 0) {
             temp["rate"] = 0;
           }
         } else {
@@ -176,7 +176,7 @@ function processCsv(csv) {
     if (stats[value["level"]] && stats[value["level"]]["total"] >= 0) {
       stats[value["level"]]["total"]++;
       // for debug
-      if(value["level"] == 12) {
+      if (value["level"] == 12) {
         console.dir(value);
         console.log(stats[value["level"]]["total"]);
       }
@@ -276,25 +276,22 @@ function processCsv(csv) {
     `;
   stastics.push(stastics_header);
   for (let i = 12; i >= 1; i--) {
+    const row = stats[i];
     stastics.push("<tr>");
     stastics.push("<td>" + "☆" + i + "</td>");
-    stastics.push(
-      "<td>" + stats[i]["played"] + "/" + stats[i]["total"] + "</td>"
-    );
-    stastics.push(
-      "<td>" + (stats[i]["average_rate"] * 100).toFixed(3) + "%</td>"
-    );
-    stastics.push("<td>" + stats[i]["1keta"] + "</td>");
-    stastics.push("<td>" + stats[i]["2keta"] + "</td>");
-    stastics.push("<td>" + stats[i]["99%"] + "</td>");
-    stastics.push("<td>" + stats[i]["98%"] + "</td>");
-    stastics.push("<td>" + stats[i]["97%"] + "</td>");
-    stastics.push("<td>" + stats[i]["96%"] + "</td>");
-    stastics.push("<td>" + stats[i]["95%"] + "</td>");
-    stastics.push("<td>" + stats[i]["MAX-"] + "</td>");
-    stastics.push("<td>" + stats[i]["AAA"] + "</td>");
-    stastics.push("<td>" + stats[i]["AA"] + "</td>");
-    stastics.push("<td>" + stats[i]["A"] + "</td>");
+    stastics.push("<td>" + row["played"] + "/" + row["total"] + "</td>");
+    stastics.push("<td>" + (row["average_rate"] * 100).toFixed(3) + "%</td>");
+    [
+      "1keta",
+      "2keta",
+      ...[...Array(5)].map((_, i) => 100 - (i + 1) + "%"),
+      "MAX-",
+      "AAA",
+      "AA",
+      "A",
+    ].forEach((name) => {
+      stastics.push(createStasticsCell(row, name));
+    });
   }
   stastics.push("</table>");
 
@@ -363,7 +360,10 @@ function processCsv(csv) {
 
   for (const s of ret) {
     // console.log(s);
-    if (document.getElementById("check_12").checked === true && s["level"] !== "12"){
+    if (
+      document.getElementById("check_12").checked === true &&
+      s["level"] !== "12"
+    ) {
       continue;
     }
     list.push("<tr>");
@@ -385,9 +385,23 @@ function processCsv(csv) {
   };
 }
 
+const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
+
+function createStasticsCell(row, name) {
+  const value = row[name];
+  const alpha = value / row["total"];
+  const style =
+    "background-color: rgba(" + HEATMAP_BACKGROUND_COLOR + ", " + alpha + ");";
+  return '<td style="' + style + '">' + value + "</td>";
+}
+
 window.onload = function () {
   let button = document.getElementById("sub");
 
   getMusicData();
   button.onclick = setTextareaData;
 };
+
+function toggleHeatmap(checked) {
+  document.getElementById("stastics").classList.toggle("heatmap", checked);
+}

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,5 @@
+const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
+
 let raw_data;
 let music_data;
 let xhr = new XMLHttpRequest();
@@ -384,8 +386,6 @@ function processCsv(csv) {
     statistics_summary: statistics_summary.join(""),
   };
 }
-
-const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
 function createStatisticsCell(row, name) {
   const value = row[name];


### PR DESCRIPTION
視覚的に分かったら面白いかなと思ったので、ヒートマップっぽい表示ができるようにしてみました。
`Enable heatmap`にチェックを入れるとstatisticsのテーブルのセルの色が変わります。

![image](https://user-images.githubusercontent.com/16271994/122394337-d2a2a400-cfb0-11eb-82bb-036cb129f360.png)

- 現在のメインカラー`#118bee`をMAXとして、`そのランクの曲数/レベルごとの曲数`で透過度を計算しています
- 直接関係ない行の変更は、prettierによる自動修正&ちょっとリファクタリング&typo修正です
- 動作確認はしていますが、念のためお手元でもご確認をお願いします
