### PR TITLE
いろいろリファクタリング

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,6 +1,6 @@
 const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
-let music_data;
+let musicData;
 const xhr = new XMLHttpRequest();
 const filepath = "master_sp_songs.csv";
 
@@ -24,8 +24,8 @@ function getMusicData() {
         break;
       case 4: // データ受信完了.
         if (xhr.status === 200 || xhr.status === 304) {
-          music_data = xhr.responseText; // responseXML もあり
-          console.log("COMPLETE! :" + music_data);
+          musicData = xhr.responseText; // responseXML もあり
+          console.log("COMPLETE! :" + musicData);
         } else {
           console.log("Failed. HttpStatus: " + xhr.statusText);
         }
@@ -36,34 +36,35 @@ function getMusicData() {
 }
 
 async function setTextareaData() {
-  let raw_data;
-  const tmp_data = document.getElementById("csv").value;
-  if (!tmp_data && navigator.clipboard) {
+  let rawData;
+  const tmpData = document.getElementById("csv").value;
+  if (!tmpData && navigator.clipboard) {
     // inputが空でClipboard APIが使えるならクリップボードのデータを読み込む
     // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
-    raw_data = await navigator.clipboard.readText();
+    rawData = await navigator.clipboard.readText();
   } else {
     // そうでなければinputのデータを使う
-    raw_data = tmp_data;
+    rawData = tmpData;
   }
-  const data = processCsv(raw_data);
-  document.getElementById("list").innerHTML = data["list"];
-  document.getElementById("statistics").innerHTML = data["statistics"];
-  let tweet_url =
+  const data = processCsv(rawData);
+  const tweetUrl =
     '<a href="https://twitter.com/intent/tweet?hashtags=beat_motivator&ref_src=twsrc%5Etfw&text=' +
     encodeURI(data["statistics_summary"]) +
     '&tw_p=tweetbutton&url=https%3A%2F%2Fgoofy-wiles-fc39fe.netlify.app%2F" target="_blank" rel="noopener noreferrer"> Tweet your IIDX stats!! </a>';
-  document.getElementById("tweet_button").innerHTML = tweet_url;
+
+  document.getElementById("list").innerHTML = data["list"];
+  document.getElementById("statistics").innerHTML = data["statistics"];
+  document.getElementById("tweet_button").innerHTML = tweetUrl;
 }
 
 function getMasterdata() {
   const ret = [];
-  const splittedData = music_data.split("\n");
+  const splittedData = musicData.split("\n");
   for (const line of splittedData) {
     const cols = line.split(",");
     if (cols.length < 2 || cols[0] === "version_full") {
       console.log(cols);
-      continue; // skip hedder
+      continue; // skip header
     }
 
     ret.push({
@@ -90,7 +91,7 @@ function processCsv(csv) {
   for (const line of splittedData) {
     const cols = line.split(",");
     if (cols[0] === "バージョン") {
-      continue; // skip hedder
+      continue; // skip header
     }
     csvData.push({
       title: cols[1],
@@ -125,12 +126,12 @@ function processCsv(csv) {
   }
   // console.dir(csvData);
 
-  const master_data = getMasterdata();
-  // console.dir(master_data);
+  const masterData = getMasterdata();
+  // console.dir(masterData);
 
-  const master_data_song = {};
-  for (const data of master_data) {
-    master_data_song[data["title"] + "_" + data["difficulty"]] = {
+  const masterDataSong = {};
+  for (const data of masterData) {
+    masterDataSong[data["title"] + "_" + data["difficulty"]] = {
       version: data["version"],
       level: data["level"],
       notes: data["notes"],
@@ -138,7 +139,7 @@ function processCsv(csv) {
       top_score: data["top_score"],
     };
   }
-  // console.dir(master_data_song);
+  // console.dir(masterDataSong);
   const ret = [];
 
   for (const song of csvData) {
@@ -151,12 +152,12 @@ function processCsv(csv) {
         temp["title"] = song["title"];
         temp["difficulty"] = difficulty;
         temp["score"] = song[difficulty + "_score"];
-        if (master_data_song[key]) {
+        if (masterDataSong[key]) {
           temp["rate"] =
-            song[difficulty + "_score"] / master_data_song[key]["notes"] / 2;
-          temp["notes"] = master_data_song[key]["notes"];
+            song[difficulty + "_score"] / masterDataSong[key]["notes"] / 2;
+          temp["notes"] = masterDataSong[key]["notes"];
           temp["max-"] =
-            master_data_song[key]["notes"] * 2 - song[difficulty + "_score"];
+            masterDataSong[key]["notes"] * 2 - song[difficulty + "_score"];
           // rate validation
           if (temp["rate"] < 0) {
             temp["rate"] = 0;
@@ -179,14 +180,14 @@ function processCsv(csv) {
 
   const stats = {};
 
-  for (let [key, value] of Object.entries(master_data_song)) {
+  for (let [key, value] of Object.entries(masterDataSong)) {
     if (value["level"] === "-1") {
       continue;
     }
     if (stats[value["level"]] && stats[value["level"]]["total"] >= 0) {
       stats[value["level"]]["total"]++;
       // for debug
-      if (value["level"] === 12) {
+      if (value["level"] === "12") {
         console.dir(value);
         console.log(stats[value["level"]]["total"]);
       }
@@ -264,7 +265,7 @@ function processCsv(csv) {
   console.dir(stats);
 
   const statistics = ["<table>"];
-  const statistics_header = `
+  const statisticsHeader = `
     <thead>
     <tr>
     <td> ☆ </td>
@@ -284,7 +285,7 @@ function processCsv(csv) {
     </tr>
     </thead>
     `;
-  statistics.push(statistics_header);
+  statistics.push(statisticsHeader);
   for (let i = 12; i >= 1; i--) {
     const row = stats[i];
     statistics.push("<tr>");
@@ -305,10 +306,10 @@ function processCsv(csv) {
   }
   statistics.push("</table>");
 
-  const statistics_summary = [];
-  let num_1keta = 0;
-  let num_99p = 0;
-  let num_98p = 0;
+  const statisticsSummary = [];
+  let num1keta = 0;
+  let num99p = 0;
+  let num98p = 0;
   for (let i = 12; i >= 1; i--) {
     let temp = "";
     if (i === 12) {
@@ -326,7 +327,7 @@ function processCsv(csv) {
       temp += "97%: " + stats[i]["97%"] + " / ";
       temp += "max-: " + stats[i]["MAX-"] + " / ";
       temp += "AAA: " + stats[i]["AAA"] + "\n";
-      statistics_summary.push(temp);
+      statisticsSummary.push(temp);
     } else if (i === 11) {
       temp +=
         "☆11 avg: " +
@@ -342,20 +343,20 @@ function processCsv(csv) {
       temp += "97%: " + stats[i]["97%"] + " / ";
       temp += "max-: " + stats[i]["MAX-"] + " / ";
       temp += "AAA: " + stats[i]["AAA"] + "\n";
-      statistics_summary.push(temp);
+      statisticsSummary.push(temp);
     }
-    num_1keta += stats[i]["1keta"];
-    num_99p += stats[i]["99%"];
-    num_98p += stats[i]["98%"];
+    num1keta += stats[i]["1keta"];
+    num99p += stats[i]["99%"];
+    num98p += stats[i]["98%"];
   }
-  statistics_summary.push("Total | max-*: " + num_1keta + " / ");
-  statistics_summary.push("99%: " + num_99p + " / ");
-  statistics_summary.push("98%: " + num_98p + "\n\n");
+  statisticsSummary.push("Total | max-*: " + num1keta + " / ");
+  statisticsSummary.push("99%: " + num99p + " / ");
+  statisticsSummary.push("98%: " + num98p + "\n\n");
 
-  console.log(statistics_summary.join(""));
+  console.log(statisticsSummary.join(""));
 
   const list = ["<table>"];
-  const list_header = `
+  const listHeader = `
     <thead>
     <tr>
     <td> ☆ </td>
@@ -366,7 +367,7 @@ function processCsv(csv) {
     </tr>
     </thead>
     `;
-  list.push(list_header);
+  list.push(listHeader);
 
   for (const s of ret) {
     // console.log(s);
@@ -391,7 +392,7 @@ function processCsv(csv) {
   return {
     list: list.join(""),
     statistics: statistics.join(""),
-    statistics_summary: statistics_summary.join(""),
+    statistics_summary: statisticsSummary.join(""),
   };
 }
 

--- a/public/script.js
+++ b/public/script.js
@@ -23,14 +23,14 @@ function fetchSongDataFile() {
 
 async function setTextareaData() {
   let rawData;
-  const tmpData = document.getElementById("csv").value;
-  if (!tmpData && navigator.clipboard) {
+  const csvInput = document.getElementById("csv").value;
+  if (!csvInput && navigator.clipboard) {
     // inputが空でClipboard APIが使えるならクリップボードのデータを読み込む
     // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
     rawData = await navigator.clipboard.readText();
   } else {
     // そうでなければinputのデータを使う
-    rawData = tmpData;
+    rawData = csvInput;
   }
   const data = processCsv(rawData);
   const tweetUrl =

--- a/public/script.js
+++ b/public/script.js
@@ -1,8 +1,7 @@
 const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
-let raw_data;
 let music_data;
-let xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 const filepath = "master_sp_songs.csv";
 
 function getMusicData() {
@@ -37,8 +36,9 @@ function getMusicData() {
 }
 
 async function setTextareaData() {
+  let raw_data;
   const tmp_data = document.getElementById("csv").value;
-  if(!tmp_data && navigator.clipboard) {
+  if (!tmp_data && navigator.clipboard) {
     // inputが空でClipboard APIが使えるならクリップボードのデータを読み込む
     // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
     raw_data = await navigator.clipboard.readText();
@@ -46,7 +46,7 @@ async function setTextareaData() {
     // そうでなければinputのデータを使う
     raw_data = tmp_data;
   }
-  let data = processCsv(raw_data);
+  const data = processCsv(raw_data);
   document.getElementById("list").innerHTML = data["list"];
   document.getElementById("statistics").innerHTML = data["statistics"];
   let tweet_url =
@@ -57,78 +57,78 @@ async function setTextareaData() {
 }
 
 function getMasterdata() {
-  let ret = [];
-  let temp = music_data.split("\n");
-  for (const line of temp) {
-    temp = line.split(",");
-    if (temp.length < 2 || temp[0] === "version_full") {
-      console.log(temp);
+  const ret = [];
+  const splittedData = music_data.split("\n");
+  for (const line of splittedData) {
+    const cols = line.split(",");
+    if (cols.length < 2 || cols[0] === "version_full") {
+      console.log(cols);
       continue; // skip hedder
     }
 
     ret.push({
-      title: temp[1],
-      version: temp[0],
-      difficulty: temp[5],
-      level: temp[7],
-      notes: temp[8],
-      kaiden_average: temp[9],
-      top_score: temp[10],
+      title: cols[1],
+      version: cols[0],
+      difficulty: cols[5],
+      level: cols[7],
+      notes: cols[8],
+      kaiden_average: cols[9],
+      top_score: cols[10],
     });
   }
   return ret;
 }
 
 function processCsv(csv) {
-  splittedData = csv.split("\n");
+  const splittedData = csv.split("\n");
   if (splittedData[0].split(",")[0] !== "バージョン") {
     return "CSV 入れて！！！！！！";
   }
 
-  let csvData = [];
+  const csvData = [];
 
   for (const line of splittedData) {
-    temp = line.split(",");
-    if (temp[0] === "バージョン") {
+    const cols = line.split(",");
+    if (cols[0] === "バージョン") {
       continue; // skip hedder
     }
     csvData.push({
-      title: temp[1],
-      version: temp[0],
-      playcount: temp[4],
-      SPB_level: temp[5],
-      SPB_score: temp[6],
-      SPB_misscount: temp[9],
-      SPB_clearlamp: temp[10],
-      SPB_djlevel: temp[11],
-      SPN_level: temp[12],
-      SPN_score: temp[13],
-      SPN_misscount: temp[16],
-      SPN_clearlamp: temp[17],
-      SPN_djlevel: temp[18],
-      SPH_level: temp[19],
-      SPH_score: temp[20],
-      SPH_misscount: temp[23],
-      SPH_clearlamp: temp[24],
-      SPH_djlevel: temp[25],
-      SPA_level: temp[26],
-      SPA_score: temp[27],
-      SPA_misscount: temp[30],
-      SPA_clearlamp: temp[31],
-      SPA_djlevel: temp[32],
-      SPL_level: temp[33],
-      SPL_score: temp[34],
-      SPL_misscount: temp[37],
-      SPL_clearlamp: temp[38],
-      SPL_djlevel: temp[39],
+      title: cols[1],
+      version: cols[0],
+      playcount: cols[4],
+      SPB_level: cols[5],
+      SPB_score: cols[6],
+      SPB_misscount: cols[9],
+      SPB_clearlamp: cols[10],
+      SPB_djlevel: cols[11],
+      SPN_level: cols[12],
+      SPN_score: cols[13],
+      SPN_misscount: cols[16],
+      SPN_clearlamp: cols[17],
+      SPN_djlevel: cols[18],
+      SPH_level: cols[19],
+      SPH_score: cols[20],
+      SPH_misscount: cols[23],
+      SPH_clearlamp: cols[24],
+      SPH_djlevel: cols[25],
+      SPA_level: cols[26],
+      SPA_score: cols[27],
+      SPA_misscount: cols[30],
+      SPA_clearlamp: cols[31],
+      SPA_djlevel: cols[32],
+      SPL_level: cols[33],
+      SPL_score: cols[34],
+      SPL_misscount: cols[37],
+      SPL_clearlamp: cols[38],
+      SPL_djlevel: cols[39],
     });
   }
   // console.dir(csvData);
 
-  let master_data = getMasterdata();
+  const master_data = getMasterdata();
   // console.dir(master_data);
 
-  let master_data_song = {};
+  const master_data_song = {};
   for (const data of master_data) {
     master_data_song[data["title"] + "_" + data["difficulty"]] = {
       version: data["version"],
@@ -139,13 +139,13 @@ function processCsv(csv) {
     };
   }
   // console.dir(master_data_song);
-  let ret = [];
+  const ret = [];
 
   for (const song of csvData) {
     const difficulties = ["SPB", "SPN", "SPH", "SPA", "SPL"];
     for (const difficulty of difficulties) {
       if (song[difficulty + "_score"] > 0) {
-        let temp = {};
+        const temp = {};
         const key = song["title"] + "_" + difficulty;
         temp["level"] = song[difficulty + "_level"];
         temp["title"] = song["title"];
@@ -177,7 +177,7 @@ function processCsv(csv) {
     if (a["rate"] < b["rate"]) return 1;
   });
 
-  let stats = {};
+  const stats = {};
 
   for (let [key, value] of Object.entries(master_data_song)) {
     if (value["level"] === "-1") {
@@ -263,8 +263,8 @@ function processCsv(csv) {
 
   console.dir(stats);
 
-  let statistics = ["<table>"];
-  let statistics_header = `
+  const statistics = ["<table>"];
+  const statistics_header = `
     <thead>
     <tr>
     <td> ☆ </td>
@@ -305,7 +305,7 @@ function processCsv(csv) {
   }
   statistics.push("</table>");
 
-  let statistics_summary = [];
+  const statistics_summary = [];
   let num_1keta = 0;
   let num_99p = 0;
   let num_98p = 0;
@@ -354,8 +354,8 @@ function processCsv(csv) {
 
   console.log(statistics_summary.join(""));
 
-  let list = ["<table>"];
-  let list_header = `
+  const list = ["<table>"];
+  const list_header = `
     <thead>
     <tr>
     <td> ☆ </td>
@@ -404,7 +404,7 @@ function createStatisticsCell(row, name) {
 }
 
 window.onload = function () {
-  let button = document.getElementById("sub");
+  const button = document.getElementById("sub");
 
   getMusicData();
   button.onclick = setTextareaData;

--- a/public/script.js
+++ b/public/script.js
@@ -285,10 +285,10 @@ function processCsv(csv) {
     </thead>
     `;
   statistics.push(statisticsHeader);
-  for (let i = 12; i >= 1; i--) {
-    const row = stats[i];
+  for (let lv = 12; lv >= 1; lv--) {
+    const row = stats[lv];
     statistics.push("<tr>");
-    statistics.push("<td>" + "☆" + i + "</td>");
+    statistics.push("<td>" + "☆" + lv + "</td>");
     statistics.push("<td>" + row["played"] + "/" + row["total"] + "</td>");
     statistics.push("<td>" + (row["average_rate"] * 100).toFixed(3) + "%</td>");
     [
@@ -309,45 +309,13 @@ function processCsv(csv) {
   let num1keta = 0;
   let num99p = 0;
   let num98p = 0;
-  for (let i = 12; i >= 1; i--) {
-    if (i === 12) {
-      let line = "";
-      line +=
-        "☆12 avg: " +
-        (stats[i]["average_rate"] * 100).toFixed(2) +
-        "% (" +
-        stats[i]["played"] +
-        "/" +
-        stats[i]["total"] +
-        ") | ";
-      line += "max-**: " + stats[i]["2keta"] + " / ";
-      line += "99%: " + stats[i]["99%"] + " / ";
-      line += "98%: " + stats[i]["98%"] + " / ";
-      line += "97%: " + stats[i]["97%"] + " / ";
-      line += "max-: " + stats[i]["MAX-"] + " / ";
-      line += "AAA: " + stats[i]["AAA"] + "\n";
-      statisticsSummary.push(line);
-    } else if (i === 11) {
-      let line = "";
-      line +=
-        "☆11 avg: " +
-        (stats[i]["average_rate"] * 100).toFixed(2) +
-        "% (" +
-        stats[i]["played"] +
-        "/" +
-        stats[i]["total"] +
-        ") | ";
-      line += "max-**: " + stats[i]["2keta"] + " / ";
-      line += "99%: " + stats[i]["99%"] + " / ";
-      line += "98%: " + stats[i]["98%"] + " / ";
-      line += "97%: " + stats[i]["97%"] + " / ";
-      line += "max-: " + stats[i]["MAX-"] + " / ";
-      line += "AAA: " + stats[i]["AAA"] + "\n";
-      statisticsSummary.push(line);
+  for (let lv = 12; lv >= 1; lv--) {
+    if (lv === 12 || lv === 11) {
+      statisticsSummary.push(statSummaryLineOfLevel(stats, lv));
     }
-    num1keta += stats[i]["1keta"];
-    num99p += stats[i]["99%"];
-    num98p += stats[i]["98%"];
+    num1keta += stats[lv]["1keta"];
+    num99p += stats[lv]["99%"];
+    num98p += stats[lv]["98%"];
   }
   statisticsSummary.push("Total | max-*: " + num1keta + " / ");
   statisticsSummary.push("99%: " + num99p + " / ");
@@ -403,6 +371,27 @@ function processCsv(csv) {
     statistics: statistics.join(""),
     statistics_summary: statisticsSummary.join(""),
   };
+}
+
+function statSummaryLineOfLevel(stats, lv) {
+  let line = "";
+  line +=
+    "☆" +
+    lv +
+    " avg: " +
+    (stats[lv]["average_rate"] * 100).toFixed(2) +
+    "% (" +
+    stats[lv]["played"] +
+    "/" +
+    stats[lv]["total"] +
+    ") | ";
+  line += "max-**: " + stats[lv]["2keta"] + " / ";
+  line += "99%: " + stats[lv]["99%"] + " / ";
+  line += "98%: " + stats[lv]["98%"] + " / ";
+  line += "97%: " + stats[lv]["97%"] + " / ";
+  line += "max-: " + stats[lv]["MAX-"] + " / ";
+  line += "AAA: " + stats[lv]["AAA"] + "\n";
+  return line;
 }
 
 function createStatisticsCell(row, name) {

--- a/public/script.js
+++ b/public/script.js
@@ -173,10 +173,8 @@ function processCsv(csv) {
     }
   }
 
-  songScores.sort(function (a, b) {
-    if (a["rate"] > b["rate"]) return -1;
-    if (a["rate"] < b["rate"]) return 1;
-  });
+  // sort by rate, in descending order
+  songScores.sort((a, b) => b["rate"] - a["rate"]);
 
   const stats = {};
   for (const song of Object.values(masterDataSong)) {

--- a/public/script.js
+++ b/public/script.js
@@ -1,38 +1,24 @@
 const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
 let musicData;
-const xhr = new XMLHttpRequest();
 const songDataFilepath = "master_sp_songs.csv";
 
 function fetchSongDataFile() {
-  xhr.open("GET", songDataFilepath);
-
-  xhr.onreadystatechange = function () {
-    switch (xhr.readyState) {
-      case 0:
-        // 未初期化状態.
-        console.log("uninitialized!");
-        break;
-      case 1: // データ送信中.
-        console.log("loading...");
-        break;
-      case 2: // 応答待ち.
-        console.log("loaded.");
-        break;
-      case 3: // データ受信中.
-        console.log("interactive... " + xhr.responseText.length + " bytes.");
-        break;
-      case 4: // データ受信完了.
-        if (xhr.status === 200 || xhr.status === 304) {
-          musicData = xhr.responseText; // responseXML もあり
-          console.log("COMPLETE! :" + musicData);
-        } else {
-          console.log("Failed. HttpStatus: " + xhr.statusText);
-        }
-        break;
-    }
-  };
-  xhr.send(null);
+  fetch(songDataFilepath)
+    .then((res) => {
+      if (res.status === 200 || res.status === 304) {
+        return res.text();
+      } else {
+        throw new Error(res.statusText);
+      }
+    })
+    .then((resText) => {
+      musicData = resText;
+      console.log("COMPLETE! :" + resText);
+    })
+    .catch((statusText) => {
+      console.log("Failed. HttpStatus: " + statusText);
+    });
 }
 
 async function setTextareaData() {

--- a/public/script.js
+++ b/public/script.js
@@ -1,6 +1,6 @@
 const HEATMAP_BACKGROUND_COLOR = "17, 139, 238";
 
-let musicData;
+let songData;
 const songDataFilepath = "master_sp_songs.csv";
 
 function fetchSongDataFile() {
@@ -13,11 +13,11 @@ function fetchSongDataFile() {
       }
     })
     .then((resText) => {
-      musicData = resText;
-      console.log("COMPLETE! :" + resText);
+      songData = resText;
+      console.log("COMPLETE! :", resText);
     })
     .catch((statusText) => {
-      console.log("Failed. HttpStatus: " + statusText);
+      console.log("Failed. HttpStatus:", statusText);
     });
 }
 
@@ -45,7 +45,7 @@ async function setTextareaData() {
 
 function getMasterdata() {
   const ret = [];
-  const splittedData = musicData.split("\n");
+  const splittedData = songData.split("\n");
   for (const line of splittedData) {
     const cols = line.split(",");
     if (cols.length < 2 || cols[0] === "version_full") {
@@ -83,31 +83,41 @@ function processCsv(csv) {
       title: cols[1],
       version: cols[0],
       playcount: cols[4],
-      SPB_level: cols[5],
-      SPB_score: cols[6],
-      SPB_misscount: cols[9],
-      SPB_clearlamp: cols[10],
-      SPB_djlevel: cols[11],
-      SPN_level: cols[12],
-      SPN_score: cols[13],
-      SPN_misscount: cols[16],
-      SPN_clearlamp: cols[17],
-      SPN_djlevel: cols[18],
-      SPH_level: cols[19],
-      SPH_score: cols[20],
-      SPH_misscount: cols[23],
-      SPH_clearlamp: cols[24],
-      SPH_djlevel: cols[25],
-      SPA_level: cols[26],
-      SPA_score: cols[27],
-      SPA_misscount: cols[30],
-      SPA_clearlamp: cols[31],
-      SPA_djlevel: cols[32],
-      SPL_level: cols[33],
-      SPL_score: cols[34],
-      SPL_misscount: cols[37],
-      SPL_clearlamp: cols[38],
-      SPL_djlevel: cols[39],
+      SPB: {
+        level: cols[5],
+        score: cols[6],
+        misscount: cols[9],
+        clearlamp: cols[10],
+        djlevel: cols[11],
+      },
+      SPN: {
+        level: cols[12],
+        score: cols[13],
+        misscount: cols[16],
+        clearlamp: cols[17],
+        djlevel: cols[18],
+      },
+      SPH: {
+        level: cols[19],
+        score: cols[20],
+        misscount: cols[23],
+        clearlamp: cols[24],
+        djlevel: cols[25],
+      },
+      SPA: {
+        level: cols[26],
+        score: cols[27],
+        misscount: cols[30],
+        clearlamp: cols[31],
+        djlevel: cols[32],
+      },
+      SPL: {
+        level: cols[33],
+        score: cols[34],
+        misscount: cols[37],
+        clearlamp: cols[38],
+        djlevel: cols[39],
+      },
     });
   }
   // console.dir(csvData);
@@ -117,7 +127,7 @@ function processCsv(csv) {
 
   const masterDataSong = {};
   for (const data of masterData) {
-    masterDataSong[data["title"] + "_" + data["difficulty"]] = {
+    masterDataSong[`${data["title"]}_${data["difficulty"]}`] = {
       version: data["version"],
       level: data["level"],
       notes: data["notes"],
@@ -131,19 +141,19 @@ function processCsv(csv) {
   for (const song of csvData) {
     const difficulties = ["SPB", "SPN", "SPH", "SPA", "SPL"];
     for (const difficulty of difficulties) {
-      if (song[difficulty + "_score"] > 0) {
+      if (song[difficulty]["score"] > 0) {
         const songScore = {};
-        const key = song["title"] + "_" + difficulty;
-        songScore["level"] = song[difficulty + "_level"];
+        const key = `${song["title"]}_${difficulty}`;
+        songScore["level"] = song[difficulty]["level"];
         songScore["title"] = song["title"];
         songScore["difficulty"] = difficulty;
-        songScore["score"] = song[difficulty + "_score"];
+        songScore["score"] = song[difficulty]["score"];
         if (masterDataSong[key]) {
           songScore["rate"] =
-            song[difficulty + "_score"] / masterDataSong[key]["notes"] / 2;
+            song[difficulty]["score"] / masterDataSong[key]["notes"] / 2;
           songScore["notes"] = masterDataSong[key]["notes"];
           songScore["max-"] =
-            masterDataSong[key]["notes"] * 2 - song[difficulty + "_score"];
+            masterDataSong[key]["notes"] * 2 - song[difficulty]["score"];
           // rate validation
           if (songScore["rate"] < 0) {
             songScore["rate"] = 0;
@@ -152,7 +162,7 @@ function processCsv(csv) {
           songScore["rate"] = 0.0;
           songScore["notes"] = 1;
           songScore["max-"] = 9999;
-          console.log("not found:" + key);
+          console.log("not found:", key);
         }
         songScores.push(songScore);
       }
@@ -274,13 +284,13 @@ function processCsv(csv) {
   for (let lv = 12; lv >= 1; lv--) {
     const row = stats[lv];
     statistics.push("<tr>");
-    statistics.push("<td>" + "☆" + lv + "</td>");
-    statistics.push("<td>" + row["played"] + "/" + row["total"] + "</td>");
-    statistics.push("<td>" + (row["average_rate"] * 100).toFixed(3) + "%</td>");
+    statistics.push(`<td>☆${lv}</td>`);
+    statistics.push(`<td>${row["played"]}/${row["total"]}</td>`);
+    statistics.push(`<td>${(row["average_rate"] * 100).toFixed(3)}%</td>`);
     [
       "1keta",
       "2keta",
-      ...[...Array(5)].map((_, i) => 100 - (i + 1) + "%"),
+      ...[...Array(5)].map((_, i) => `${100 - (i + 1)}%`),
       "MAX-",
       "AAA",
       "AA",
@@ -303,9 +313,9 @@ function processCsv(csv) {
     num99p += stats[lv]["99%"];
     num98p += stats[lv]["98%"];
   }
-  statisticsSummary.push("Total | max-*: " + num1keta + " / ");
-  statisticsSummary.push("99%: " + num99p + " / ");
-  statisticsSummary.push("98%: " + num98p + "\n\n");
+  statisticsSummary.push(`Total | max-*: ${num1keta} / `);
+  statisticsSummary.push(`99%: ${num99p} / `);
+  statisticsSummary.push(`98%: ${num98p}\n\n`);
 
   console.log(statisticsSummary.join(""));
 
@@ -332,20 +342,11 @@ function processCsv(csv) {
       continue;
     }
     list.push("<tr>");
-    list.push("<td>☆" + songScore["level"] + "</td>");
-    list.push(
-      "<td>" +
-        songScore["title"] +
-        " (" +
-        songScore["difficulty"] +
-        ")" +
-        "</td>"
-    );
-    list.push("<td>" + songScore["score"] + "</td>");
-    list.push("<td>" + (songScore["rate"] * 100).toFixed(2) + "%</td>");
-    list.push(
-      "<td>MAX-" + (songScore["notes"] * 2 - songScore["score"]) + "</td>"
-    );
+    list.push(`<td>☆${songScore["level"]}</td>`);
+    list.push(`<td>${songScore["title"]} (${songScore["difficulty"]})</td>`);
+    list.push(`<td>${songScore["score"]}</td>`);
+    list.push(`<td>${(songScore["rate"] * 100).toFixed(2)}%</td>`);
+    list.push(`<td>MAX-${songScore["notes"] * 2 - songScore["score"]}</td>`);
     list.push("</tr>");
   }
   list.push("</table>");
@@ -361,31 +362,23 @@ function processCsv(csv) {
 
 function statSummaryLineOfLevel(stats, lv) {
   let line = "";
-  line +=
-    "☆" +
-    lv +
-    " avg: " +
-    (stats[lv]["average_rate"] * 100).toFixed(2) +
-    "% (" +
-    stats[lv]["played"] +
-    "/" +
-    stats[lv]["total"] +
-    ") | ";
-  line += "max-**: " + stats[lv]["2keta"] + " / ";
-  line += "99%: " + stats[lv]["99%"] + " / ";
-  line += "98%: " + stats[lv]["98%"] + " / ";
-  line += "97%: " + stats[lv]["97%"] + " / ";
-  line += "max-: " + stats[lv]["MAX-"] + " / ";
-  line += "AAA: " + stats[lv]["AAA"] + "\n";
+
+  const formattedAvgRate = (stats[lv]["average_rate"] * 100).toFixed(2);
+  line += `☆${lv} avg: ${formattedAvgRate}% (${stats[lv]["played"]}/${stats[lv]["total"]}) | `;
+  line += `max-**: ${stats[lv]["2keta"]} / `;
+  line += `99%: ${stats[lv]["99%"]} / `;
+  line += `98%: ${stats[lv]["98%"]} / `;
+  line += `97%: ${stats[lv]["97%"]} / `;
+  line += `max-: ${stats[lv]["MAX-"]} / `;
+  line += `AAA: ${stats[lv]["AAA"]}\n`;
   return line;
 }
 
 function createStatisticsCell(row, name) {
   const value = row[name];
   const alpha = value / row["total"];
-  const style =
-    "background-color: rgba(" + HEATMAP_BACKGROUND_COLOR + ", " + alpha + ");";
-  return '<td style="' + style + '">' + value + "</td>";
+  const style = `background-color: rgba(${HEATMAP_BACKGROUND_COLOR}, ${alpha});`;
+  return `<td style="${style}">${value}</td>`;
 }
 
 window.onload = function () {

--- a/public/script.js
+++ b/public/script.js
@@ -24,7 +24,7 @@ function getMusicData() {
         console.log("interactive... " + xhr.responseText.length + " bytes.");
         break;
       case 4: // データ受信完了.
-        if (xhr.status == 200 || xhr.status == 304) {
+        if (xhr.status === 200 || xhr.status === 304) {
           music_data = xhr.responseText; // responseXML もあり
           console.log("COMPLETE! :" + music_data);
         } else {
@@ -186,7 +186,7 @@ function processCsv(csv) {
     if (stats[value["level"]] && stats[value["level"]]["total"] >= 0) {
       stats[value["level"]]["total"]++;
       // for debug
-      if (value["level"] == 12) {
+      if (value["level"] === 12) {
         console.dir(value);
         console.log(stats[value["level"]]["total"]);
       }


### PR DESCRIPTION
独断と偏見に基づき、気になった部分をリファクタリングしてみました。結構がっつりと変えてしまいましたが、もしここは変えて欲しくなかった、という部分があればそこだけもとに戻すといった対応も可能です。

僭越ながら、今後の機能追加の礎になれば幸いです。


以下、変更箇所に関する簡単な説明になります。

### 等価性比較に `==` ではなく `===` を使うように変更

`==` (`!=`) は左辺と右辺のデータ型が異なる際の結果が直感的でない場合があるため、特別な理由がない限り使わないほうがよいです。`===` (`!==`) は左右のデータ型が異なる場合は必ず結果が `false` (`true`) になります。


### `const` と `let` の使い分けを修正

`const` で宣言された変数は **再代入** が不可能になります。再代入されないにもかかわらず `let` で宣言された変数があったので、`const` に変更しました。特に、配列やオブジェクトの中身の変更は再代入にはあたらないため、中身を変更したいがために `let` で宣言する必要はなく、`const` で十分になります。

一部 `const` / `let` / `var` で宣言されていない変数に代入している箇所がありましたが、このような変数は意図せずグローバル変数になるようなので、注意が必要です(こちらも修正しました)。
参考: https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Grammar_and_types#declaring_variables


### 変数名をスネークケース(snake_case)からキャメルケース(camelCase)に変更

JavaScriptの一般的な命名規則では、変数名にキャメルケースを使う場合が多いので、それに従って変更しました。ただし、オブジェクトのプロパティ名の変更については慎重な判断が必要と思われたため、基本的にそのままにしてあります。
参考: [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html#naming-rules-by-identifier-type)


### 複雑な文字列連結をテンプレートリテラルに置き換え

[テンプレートリテラル](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Template_literals)を使うと、式(具体的には変数の中身や計算結果など)を文字列に埋め込む処理を読みやすく記述できます。`"` や `'` を含む文字列をエスケープなしで書けるのも地味に便利です。

```js
const title = "冥(SPA)";
const score = 3916;
const notes = 2000;
const rate = score / notes / 2;

const rateInfo1 =  title + ": " + (rate * 100).toFixed(2) + "% (" + score + " / " + (notes * 2) + ")"; // 通常の文字列連結
const rateInfo2 = `${title}: ${(rate * 100).toFixed(2)}% (${score} / ${notes * 2})`; // テンプレートリテラル
console.log(rateInfo2); // => "冥(SPA): 97.90% (3916 / 4000)"
```


###  XMLHttpRequest を fetch に置き換え

[Fetch API](https://developer.mozilla.org/ja/docs/Web/API/Fetch_API) は XMLHttpRequest と同様 HTTP リクエストによってデータを取得するための機能ですが、処理をよりシンプルに記述できるようになっています。 ~~今回のように1ファイルを取得するだけだと正直大きな違いにはなりませんが…~~


### その他
- 複数の関数から参照されないためグローバルである必要がないグローバル変数を削除
- 情報量のある変数名に変更
  + `temp`, `data` といった名前が多く、それぞれ何を指しているのかがひと目で分かりづらいと感じたため
- ツイート用のレベル別サマリーの文字列生成処理を関数(`statSummaryLineOfLevel`)に切り出し
  + レベルの数字以外、処理内容が被っていたので
- 曲別スコアレートのソート用比較関数を修正
  + レートが一致するときの返り値が `undefined` になっていた
  + `a` と `b`を比べて `a` を先に並べる場合は負の値、`a`を後ろに並べる場合は正の値を返せばいいので、数値に基づく比較の場合は単純に引き算の結果を返せばOK