### PR TITLE
Remove invalid song data from stats

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -168,13 +168,10 @@ function processCsv(csv) {
           if (songScore["rate"] < 0) {
             songScore["rate"] = 0;
           }
+          songScores.push(songScore);
         } else {
-          songScore["rate"] = 0.0;
-          songScore["notes"] = 1;
-          songScore["max-"] = 9999;
           console.log("not found:", key);
         }
-        songScores.push(songScore);
       }
     }
   }
@@ -212,9 +209,6 @@ function processCsv(csv) {
 
   // 統計情報の作成
   for (const s of songScores) {
-    if (s["max-"] === 9999) {
-      continue; // because we have no data about this song.
-    }
     if (s["level"] === "0") {
       continue;
     }

--- a/public/script.js
+++ b/public/script.js
@@ -157,7 +157,7 @@ function processCsv(csv) {
         songScore["title"] = song["title"];
         songScore["difficulty"] = difficulty;
         songScore["score"] = song[difficulty]["score"];
-        if (masterDataSong[key]) {
+        if (masterDataSong[key] && masterDataSong[key]["notes"] > 0) {
           songScore["version"] = masterDataSong[key]["version"];
           songScore["rate"] =
             song[difficulty]["score"] / masterDataSong[key]["notes"] / 2;


### PR DESCRIPTION
This fixes the case where a chart that exists in `master_sp_songs.csv` but does not have note count data (for example, Violet Pulse SPL) appears in the stats (including MAX-*).

(The functional change is the first commit. The second commit just simplifies the code flow.)